### PR TITLE
Replace inplace operations in recurrent linear attention

### DIFF
--- a/fast_transformers/recurrent/attention/linear_attention.py
+++ b/fast_transformers/recurrent/attention/linear_attention.py
@@ -55,8 +55,8 @@ class RecurrentLinearAttention(Module):
             raise ValueError("The batch size changed during iteration")
 
         # Update the internal state
-        Zi += K
-        Si += torch.einsum("nhd,nhm->nhdm", K, value)
+        Zi = Zi + K
+        Si = Si + torch.einsum("nhd,nhm->nhdm", K, value)
 
         # Compute the output
         Z = 1. / (torch.einsum("nhd,nhd->nh", Q, Zi) + self.eps)


### PR DESCRIPTION
This PR replaces the inplace updates to `Zi` and `Si` with standard updates.
I found these inplace operations to cause gradient errors when chaining the transformer's output to other modules. Specifically, I encountered the following error:

```
...one of the variables needed for gradient computation has been modified by an inplace operation
```

I'm happy to provide additional information if needed.
