### PR TITLE
Replace long with int64_t 

### DIFF
--- a/fast_transformers/local_product/local_product_cpu.cpp
+++ b/fast_transformers/local_product/local_product_cpu.cpp
@@ -49,7 +49,7 @@ torch::Tensor local_dot_product(
     auto qa = queries.accessor<float, 4>();
     auto ka = keys.accessor<float, 4>();
     auto oa = output.accessor<float, 4>();
-    auto kla = key_lengths.accessor<long, 1>();
+    auto kla = key_lengths.accessor<int64_t, 1>();
     auto ama = attn_mask.accessor<float, 2>();
 
     #pragma omp parallel for collapse(2)
@@ -95,7 +95,7 @@ std::tuple<torch::Tensor, torch::Tensor> local_dot_backward(
     // Create accessors for all the arguments
     auto qa = queries.accessor<float, 4>();
     auto ka = keys.accessor<float, 4>();
-    auto kla = key_lengths.accessor<long, 1>();
+    auto kla = key_lengths.accessor<int64_t, 1>();
     auto ga = grad.accessor<float, 4>();
     auto gqa = grad_queries.accessor<float, 4>();
     auto gka = grad_keys.accessor<float, 4>();


### PR DESCRIPTION
On 64-bit Linux platforms, long resolves to long long (a 64-bit type), while on 64-bit Windows platforms, long resolves to int (a 32-bit type).

The latest commit with local attention was breaking the compilation on Windows

I replaced with int64_t that theoretically represent a 64-bit value between platforms.

BTW, I´m super excited about local attention (Relative Position Representations in fast-transformers would be a dream come true), but it is giving nan loss when I replaced with a pipeline that used linear attention. Maybe I´m doing something wrong, or it is not ready for prime time yet.