### PR TITLE
Dynamically determine extra_compile_args based on operating system.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,9 @@ For most machines installation should be as simple as:
 
     pip install --user pytorch-fast-transformers
 
+Note: macOS users should ensure they have `llvm` and `libomp` installed.
+Using the [homebrew](https://brew.sh) package manager, this can be accomplished by running `brew install llvm libomp`.
+
 Documentation
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ from itertools import dropwhile
 from os import path
 from setuptools import find_packages, setup
 from subprocess import DEVNULL, call
+import sys
+
 
 try:
     import torch

--- a/setup.py
+++ b/setup.py
@@ -67,49 +67,49 @@ def get_extensions():
             sources=[
                 "fast_transformers/hashing/hash_cpu.cpp"
             ],
-            extra_compile_args=["-fopenmp", "-ffast-math"]
+            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
         ),
         CppExtension(
             "fast_transformers.aggregate.aggregate_cpu",
             sources=[
                "fast_transformers/aggregate/aggregate_cpu.cpp"
             ],
-            extra_compile_args=["-fopenmp", "-ffast-math"]
+            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
         ),
         CppExtension(
             "fast_transformers.clustering.hamming.cluster_cpu",
             sources=[
                "fast_transformers/clustering/hamming/cluster_cpu.cpp"
             ],
-            extra_compile_args=["-fopenmp", "-ffast-math"]
+            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
         ),
         CppExtension(
             "fast_transformers.sparse_product.sparse_product_cpu",
             sources=[
                 "fast_transformers/sparse_product/sparse_product_cpu.cpp"
             ],
-            extra_compile_args=["-fopenmp", "-ffast-math"]
+            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
         ),
         CppExtension(
             "fast_transformers.sparse_product.clustered_sparse_product_cpu",
             sources=[
                 "fast_transformers/sparse_product/clustered_sparse_product_cpu.cpp"
             ],
-            extra_compile_args=["-fopenmp", "-ffast-math"]
+            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
         ),
         CppExtension(
             "fast_transformers.causal_product.causal_product_cpu",
             sources=[
                 "fast_transformers/causal_product/causal_product_cpu.cpp"
             ],
-            extra_compile_args=["-fopenmp", "-ffast-math"]
+            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
         ),
         CppExtension(
             "fast_transformers.local_product.local_product_cpu",
             sources=[
                 "fast_transformers/local_product/local_product_cpu.cpp"
             ],
-            extra_compile_args=["-fopenmp", "-ffast-math"]
+            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
         )
     ]
     if cuda_toolkit_available():

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,16 @@ def collect_metadata():
     return meta
 
 
+@lru_cache()
+def _get_extra_compile_args():
+    base_args = ["-fopenmp", "-ffast-math"]
+
+    if sys.platform == "darwin":
+        return ["-Xpreprocessor"] + base_args
+    else:
+        return base_args
+
+
 def get_extensions():
     extensions = [
         CppExtension(
@@ -67,49 +77,49 @@ def get_extensions():
             sources=[
                 "fast_transformers/hashing/hash_cpu.cpp"
             ],
-            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
+            extra_compile_args=_get_extra_compile_args()
         ),
         CppExtension(
             "fast_transformers.aggregate.aggregate_cpu",
             sources=[
                "fast_transformers/aggregate/aggregate_cpu.cpp"
             ],
-            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
+            extra_compile_args=_get_extra_compile_args()
         ),
         CppExtension(
             "fast_transformers.clustering.hamming.cluster_cpu",
             sources=[
                "fast_transformers/clustering/hamming/cluster_cpu.cpp"
             ],
-            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
+            extra_compile_args=_get_extra_compile_args()
         ),
         CppExtension(
             "fast_transformers.sparse_product.sparse_product_cpu",
             sources=[
                 "fast_transformers/sparse_product/sparse_product_cpu.cpp"
             ],
-            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
+            extra_compile_args=_get_extra_compile_args()
         ),
         CppExtension(
             "fast_transformers.sparse_product.clustered_sparse_product_cpu",
             sources=[
                 "fast_transformers/sparse_product/clustered_sparse_product_cpu.cpp"
             ],
-            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
+            extra_compile_args=_get_extra_compile_args()
         ),
         CppExtension(
             "fast_transformers.causal_product.causal_product_cpu",
             sources=[
                 "fast_transformers/causal_product/causal_product_cpu.cpp"
             ],
-            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
+            extra_compile_args=_get_extra_compile_args()
         ),
         CppExtension(
             "fast_transformers.local_product.local_product_cpu",
             sources=[
                 "fast_transformers/local_product/local_product_cpu.cpp"
             ],
-            extra_compile_args=["-Xpreprocessor", "-fopenmp", "-ffast-math"]
+            extra_compile_args=_get_extra_compile_args()
         )
     ]
     if cuda_toolkit_available():


### PR DESCRIPTION
## Overview

This PR will prepend the "-Xpreprocessor" arg to `extra_compile_args` if the operating system is determined to be 'darwin'.
This should not impact installation on other operating system. 

Closes #6.