### PR TITLE
 Add PEP 518 build system/requirements spec (pyproject.toml)

### DIFF
--- a/pyptoject.toml
+++ b/pyptoject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "torch"]
+build-backend = "setuptools.build_meta" 


### PR DESCRIPTION
fast-transformers depends on torch for its build, consequently, installing it with pip from a source dist in an environment without torch doesn't work (torch is listed as a dependency but pip tries to build before installing dependencies) and since the pypi repository has no wheels, we need to install from a source dist.

[PEP 518](https://www.python.org/dev/peps/pep-0518/) is the solution to this exact problem: it allows specifying build dependencies and a build system (in that case setuptools) and pip is now able to use this information at install time.

This PR adds a `pyproject.toml` file with the correct dependencies and build system information, which allows installing from a source dist.