### PR TITLE
Simplify and 3x Speedup CausalDotProduct CUDA Kernel for Larger Hidden Sizes

### DIFF
--- a/fast_transformers/causal_product/causal_product_cuda.cu
+++ b/fast_transformers/causal_product/causal_product_cuda.cu
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-// #define ENABLE_NVIDIA_OPTIMIZATIONS
+#define ENABLE_NVIDIA_OPTIMIZATIONS
 
 #ifdef ENABLE_NVIDIA_OPTIMIZATIONS
 namespace nvidia {

--- a/fast_transformers/causal_product/causal_product_cuda.cu
+++ b/fast_transformers/causal_product/causal_product_cuda.cu
@@ -1234,8 +1234,7 @@ __global__ void causal_dot_product_kernel(
     const int H,
     const int L,
     const int E,
-    const int M,
-    const int T
+    const int M
 ) {
     int n = blockIdx.y;
     int h = blockIdx.z;
@@ -1248,7 +1247,7 @@ __global__ void causal_dot_product_kernel(
 
     for (int e_local = 0; e_local < E_BLOCK_SIZE && e_local + e_start < E; e_local++)
       shared_kv[m + e_local * M] = kv[n][h][e_local + e_start][m];
-    for (int t=0; t<T; t++) {
+    for (int t=0; t<L; t++) {
       float res = 0;
       for (int e_local = 0; e_local < E_BLOCK_SIZE && e_local + e_start < E; e_local++) {
         shared_kv[e_local*M + m] += keys[n][h][t][e_local + e_start] * values[n][h][t][m];
@@ -1292,7 +1291,7 @@ void causal_dot_product_(const torch::Tensor queries,
       values.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
       kv.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
       product.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-      N, H, L, E, M, L
+      N, H, L, E, M
     );
 }
 
@@ -1314,136 +1313,64 @@ void causal_dot_product(const torch::Tensor queries,
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#define M_BLOCK_SIZE 4
+
 // we need shared memory to store
-// Forward direction
-// keys, values, gradout
-// kv, results
+// kv
 // Backward direction
-// queries, gradout, values
-// kv_backwards, results
+// kv_backwards
 // Shared memory usage
-// Forward
-// keys: E*T, (values, gradout): M_per_block*T, kv:E*M_per_block, results:E
-// Backward
-// queries: E*T, (values, gradout): M_per_block*T, kv:E*M_per_block, results:E
-// Total memory:
 __global__ void causal_dot_backward_query_key_kernel(
     const float_accessor queries,
     const float_accessor keys,
     const float_accessor values,
     const float_accessor grad_out,
     float_accessor kv,
-    float_accessor kv_backwards,
     float_accessor grad_queries,
     float_accessor grad_keys,
     int N,
     int H,
     int L,
     int E,
-    int M,
-    const int M_per_block,
-    const int blocks_per_sequence,
-    const int T,
-    const int l_offset
+    int M
 ) {
-    const int sequence_index = blockIdx.x / blocks_per_sequence;
-    int n = sequence_index / H;
-    int h = sequence_index % H;
+    int n = blockIdx.y;
+    int h = blockIdx.z;
 
-    int m_local = threadIdx.x / E;
-    int m_start = ((blockIdx.x % blocks_per_sequence)*M_per_block);
-    int m = m_start + m_local;
+    int m_start = blockIdx.x * M_BLOCK_SIZE;
     int e = threadIdx.x % E;
 
-    // Load the shared memory
-    // Forward memory
-    // keys: E*T, (values, gradout): M_per_block*T, kv:E*M_per_block, results:E
-    // Backward memory
-    // queries: E*T, (values, gradout): M_per_block*T, kv:E*M_per_block, results:E
-    // Load the shared memory for KV
     extern __shared__ float shared_mem[];
-    const int shared_kv_size = M_per_block * E;
+    const int shared_kv_size = M_BLOCK_SIZE * E;
     float* shared_kv = shared_mem;
     float* shared_kv_bw = shared_mem + shared_kv_size;
-    float* shared_results = shared_kv_bw + shared_kv_size;
-    float* shared_results_bw = shared_results + E;
-    float* shared_keys = shared_results_bw + E;
-    float* shared_values = shared_keys + E*T;
-    float* shared_gradout = shared_values + M_per_block*T;
-    float* shared_queries_bw = shared_gradout + M_per_block*T;
-    float* shared_values_bw = shared_queries_bw + E*T;
-    float* shared_gradout_bw = shared_values_bw + M_per_block*T;
 
-    if (threadIdx.x < E) {
-        shared_results[threadIdx.x] = 0.0;
-        shared_results_bw[threadIdx.x] = 0.0;
+    for (int m_local = 0; m_local < M_BLOCK_SIZE && m_local + m_start < M; m_local++) {
+      shared_kv[m_local * E + e] = kv[n][h][e][m_local + m_start];
+      shared_kv_bw[m_local * E + e] = 0;
     }
 
-    int t_end = (T + l_offset) <= L ? T : (L - l_offset);
-    for (int i = threadIdx.x; i < (t_end*M_per_block); i += blockDim.x)
-    {
-        int t = int(i / M_per_block) + l_offset;
-        int t_bw = L - t - 1;
-        int d = (i % M_per_block) + m_start;
-        if (d < M) {
-            shared_values[i] = values[n][h][t][d];
-            shared_gradout[i] = grad_out[n][h][t][d];
-            shared_values_bw[i] = values[n][h][t_bw][d];
-            shared_gradout_bw[i] = grad_out[n][h][t_bw][d];
-        }
+    for (int l=0; l<L; l++) {
+      float res = 0, res_bw = 0;
+      int l_b = L - l - 1;
+      for (int m_local = 0; m_local < M_BLOCK_SIZE && m_local + m_start < M; m_local++) {
+        shared_kv[m_local*E + e] += keys[n][h][l][e] * values[n][h][l][m_start + m_local];
+        shared_kv_bw[m_local*E + e] += queries[n][h][l_b][e] * grad_out[n][h][l_b][m_start + m_local];
+        res += grad_out[n][h][l][m_start + m_local] * shared_kv[m_local*E + e];
+        res_bw += values[n][h][l_b][m_start + m_local] * shared_kv_bw[m_local*E + e];
+      }
+      atomicAdd(
+        &grad_queries[n][h][l][e],
+        res
+      );
+      atomicAdd(
+        &grad_keys[n][h][l_b][e],
+        res_bw
+      );
     }
-    for (int i = threadIdx.x; i < (t_end*E); i += blockDim.x)
-    {
-        int t = int(i / E) + l_offset;
-        int t_bw = L - t - 1;
-        int d = (i % E);
-        shared_keys[i] = keys[n][h][t][d];
-        shared_queries_bw[i] = queries[n][h][t_bw][d];
+    for (int m_local = 0; m_local < M_BLOCK_SIZE && m_local + m_start < M; m_local++) {
+      kv[n][h][e][m_local + m_start] = shared_kv[m_local * E + e];
     }
-    __syncthreads();
-
-    if ((n >= N) || (m >= M)) {
-        return;
-    }
-
-    shared_kv[threadIdx.x] = kv[n][h][e][m];
-    shared_kv_bw[threadIdx.x] = kv_backwards[n][h][e][m];
-
-    for (int t=0; t<t_end; t++) {
-        int l = t + l_offset;
-        int l_b = L - l -1;
-        shared_kv[m_local*E + e] += shared_keys[t*E + e] * shared_values[t*M_per_block + m_local];
-        shared_kv_bw[m_local*E + e] += shared_queries_bw[t*E + e] * shared_gradout_bw[t*M_per_block + m_local];
-        __syncthreads();
-        float res = shared_gradout[t*M_per_block + m_local] * shared_kv[m_local*E + e];
-        float res_bw = shared_values_bw[t*M_per_block + m_local] * shared_kv_bw[m_local*E + e];
-        atomicAdd(
-            &shared_results[e],
-            res
-        );
-        atomicAdd(
-            &shared_results_bw[e],
-            res_bw
-        );
-        __syncthreads();
-        if (threadIdx.x < E) {
-            float rq = shared_results[threadIdx.x];
-            float rk = shared_results_bw[threadIdx.x];
-            atomicAdd(
-                &grad_queries[n][h][l][e],
-                rq
-            );
-            atomicAdd(
-                &grad_keys[n][h][l_b][e],
-                rk
-            );
-            shared_results[threadIdx.x] = 0.0;
-            shared_results_bw[threadIdx.x] = 0.0;
-        }
-    }
-    __syncthreads();
-    kv[n][h][e][m] = shared_kv[m_local*E + e];
-    kv_backwards[n][h][e][m] = shared_kv_bw[m_local*E + e];
 }
 
 
@@ -1459,81 +1386,33 @@ __global__ void causal_dot_backward_value_kernel(
     int H,
     int L,
     int E,
-    int M,
-    int E_per_block,
-    int blocks_per_sequence,
-    int T,
-    int l_offset
+    int M
 ) {
-    const int sequence_index = blockIdx.x / blocks_per_sequence;
-    int n = sequence_index / H;
-    int h = sequence_index % H;
+    int n = blockIdx.y;
+    int h = blockIdx.z;
 
-    int e_local = threadIdx.x / M;
-    int e_start = ((blockIdx.x % blocks_per_sequence) * E_per_block);
-    int e = e_start + e_local;
+    int e_start = blockIdx.x * E_BLOCK_SIZE;
     int m = threadIdx.x % M;
 
-    // Load the shared memory for KV
-    const int shared_kv_size = E_per_block * M;
     extern __shared__ float shared_mem[];
     float* shared_kv = shared_mem;
-    float* shared_results = shared_mem + shared_kv_size;
-    float* shared_gradout = shared_results + M;
-    float* shared_keys = shared_gradout + M*T;
-    float* shared_queries = shared_keys + E_per_block*T;
+    for (int e_local = 0; e_local < E_BLOCK_SIZE && e_local + e_start < E; e_local++)
+      shared_kv[m + e_local * M] = kv[n][h][e_local + e_start][m];
 
-    if (threadIdx.x < M) {
-        shared_results[threadIdx.x] = 0.0;
-    }
-
-    int t_end = (T + l_offset) <= L ? T : L - l_offset;
-    for (int i = threadIdx.x; i < (t_end*M); i += blockDim.x)
-    {
-        int t = int(i / M) + l_offset;
-        int t_bw = L - 1 - t;
-        int d = i % M;
-        shared_gradout[i] = grad_out[n][h][t_bw][d];
-    }
-    for (int i = threadIdx.x; i < (t_end*E_per_block); i += blockDim.x)
-    {
-        int t = int(i / E_per_block) + l_offset;
-        int t_bw = L - 1 - t;
-        int d = (i % E_per_block) + e_start;
-        if (d < E) {
-            shared_keys[i] = keys[n][h][t_bw][d];
-            shared_queries[i] = queries[n][h][t_bw][d];
-        }
-    }
-    __syncthreads();
-
-    if ((n >= N) || (e >= E)){
-        return;
-    }
-
-    shared_kv[threadIdx.x] = kv[n][h][e][m];
-    for (int t=0; t<t_end; t++) {
-        int l = t + l_offset;
+    for (int l = 0; l < L; l++) {
         int l_b = L - l -1;
-        shared_kv[e_local*M + m] += shared_queries[t*E_per_block + e_local] * shared_gradout[t*M + m];
-        __syncthreads();
-        float res = shared_keys[t*E_per_block + e_local] * shared_kv[e_local*M + m];
+        float res = 0;
+        for (int e_local = 0; e_local < E_BLOCK_SIZE && e_local + e_start < E; e_local++) {
+          shared_kv[e_local*M + m] += queries[n][h][l_b][e_start + e_local] * grad_out[n][h][l_b][m];
+          res += keys[n][h][l_b][e_start + e_local] * shared_kv[e_local*M + m];
+        }
         atomicAdd(
-            &shared_results[m],
+            &grad_values[n][h][l_b][m],
             res
         );
-        __syncthreads();
-        if (threadIdx.x < M) {
-            float r1 = shared_results[threadIdx.x];
-            atomicAdd(
-                &grad_values[n][h][l_b][m],
-                r1
-            );
-            shared_results[threadIdx.x] = 0.0;
-        }
     }
-    __syncthreads();
-    kv[n][h][e][m] = shared_kv[e_local*M + m];
+    for (int e_local = 0; e_local < E_BLOCK_SIZE && e_local + e_start < E; e_local++)
+      kv[n][h][e_local + e_start][m] = shared_kv[m + e_local * M];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1556,66 +1435,40 @@ void causal_dot_backward_(const torch::Tensor queries,
     int M = values.size(3);
 
     auto kv = torch::zeros({N, H, E, M}, queries.options());
-    auto kv_backward = torch::zeros({N, H, E, M}, queries.options());
 
-    const int threads = 1024;
-    int MUL_PER_BLOCK = min(threads, E*M);
-    // make sure that MUL_PER_BLOCK is divisible by M;
-    MUL_PER_BLOCK = int(MUL_PER_BLOCK / E) *  E;
-    const int blocks_per_sequence = ((E*M) + MUL_PER_BLOCK -1) / MUL_PER_BLOCK;
-    const int M_per_block = MUL_PER_BLOCK / E;
-    int blocks  = N*H*blocks_per_sequence;
+    const int blocks_per_sequence = (M + M_BLOCK_SIZE - 1) / M_BLOCK_SIZE;
 
-    // Forward memory
-    // keys: E*T, (values, gradout): M_per_block*T, kv:E*M_per_block, results:E
-    // Backward memory
-    // queries: E*T, (values, gradout): M_per_block*T, kv:E*M_per_block, results:E
-    // Total memory
-    // 2*((E + 2*M_per_block)*T + (E+1)*M_per_block)
-    int shared_mem_const = 2*E*(1+M_per_block);
-    int shared_mem_per_time = 2*(E + 2*M_per_block);
-    int T = int(((12 * 1024) - shared_mem_const) / shared_mem_per_time);
-    const int shared_mem_qk_backward = ((T*shared_mem_per_time) + shared_mem_const) * sizeof(float);
-    for (int l_offset=0; l_offset < L; l_offset += T) {
-        causal_dot_backward_query_key_kernel
-            <<<blocks, MUL_PER_BLOCK, shared_mem_qk_backward>>>(
-            queries.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            values.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            grad_out.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            kv.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            kv_backward.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            grad_queries.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            grad_keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            N, H, L, E, M, M_per_block, blocks_per_sequence, T, l_offset
-        );
-    }
+    dim3 blockDim(E, 1, 1);
+    dim3 gridDim(blocks_per_sequence, N, H);
+    const int shared_mem_qk_backward = 2 * M_BLOCK_SIZE * E * sizeof(float);
 
-    int MPB = min(threads, E*M);
-    // make sure that MUL_PER_BLOCK is divisible by M;
-    MPB = int(MPB / M) *  M;
-    const int blocks_per_sequence_value = ((E*M) + MPB - 1)/ MPB;
-    const int E_per_block = MPB / M;
-    const int blocks_value  = N*H*blocks_per_sequence_value;
+    causal_dot_backward_query_key_kernel<<<gridDim, blockDim, shared_mem_qk_backward>>>(
+      queries.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      values.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      grad_out.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      kv.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      grad_queries.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      grad_keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      N, H, L, E, M
+    );
 
-    shared_mem_const = (E_per_block + 1)*M;
-    shared_mem_per_time = (M + 2*E_per_block);
-    T = int(((12 * 1024) - shared_mem_const) / shared_mem_per_time);
-    const int shared_mem_v_backward = ((T*shared_mem_per_time) + shared_mem_const) * sizeof(float);
+    const int blocks_per_sequence_value = (E + E_BLOCK_SIZE - 1) / E_BLOCK_SIZE;
+
+    dim3 blockDimv(M, 1, 1);
+    dim3 gridDimv(blocks_per_sequence_value, N, H);
+    const int shared_mem_v_backward = E_BLOCK_SIZE * M * sizeof(float);
     kv.zero_();
-    for (int l_offset=0; l_offset < L; l_offset += T) {
-        causal_dot_backward_value_kernel
-            <<<blocks_value, MPB, shared_mem_v_backward>>>(
-            queries.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            values.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            grad_out.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            kv.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            grad_keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            grad_values.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
-            N, H, L, E, M, E_per_block, blocks_per_sequence_value, T, l_offset
-        );
-    }
+    causal_dot_backward_value_kernel<<<gridDimv, blockDimv, shared_mem_v_backward>>>(
+      queries.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      values.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      grad_out.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      kv.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      grad_keys.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      grad_values.packed_accessor32<float, 4, torch::RestrictPtrTraits>(),
+      N, H, L, E, M
+    );
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/causal_product/test_causal_product_gpu.py
+++ b/tests/causal_product/test_causal_product_gpu.py
@@ -84,7 +84,7 @@ class TestCausalProductCUDA(unittest.TestCase):
             self.assertLess(max_relative_error(V.grad, gv), 1e-5)
 
     def _test_benchmark_forward(self, CP):
-        print("{:>4} {:>5} {:>5} {:>5} {:>5} {:>8}".format("N", "L", "H", "E", "M", "Time (ms)"))
+        print("{:>4} {:>5} {:>5} {:>5} {:>5} {:>12}".format("N", "L", "H", "E", "M", "FW Time (ms)"))
         for N, L, H, E, M in [
             [8, 4096, 8, 512, 512],
             [1, 4096, 8, 512, 512],
@@ -117,33 +117,38 @@ class TestCausalProductCUDA(unittest.TestCase):
             ))
 
     def _test_benchmark_backward(self, CP):
-        N = 10
-        L = 1000
-        H = 10
-        E = 32
-        M = 64
-        Q = torch.rand(N, H, L, E).cuda()
-        K = torch.rand(N, H, L, E).cuda()
-        V = torch.rand(N, H, L, M).cuda()
-        go = torch.rand(N, H, L, M).cuda()
-        gq, gk, gv = [torch.zeros_like(x) for x in [Q, K, V]]
+        print("{:>4} {:>5} {:>5} {:>5} {:>5} {:>12}".format("N", "L", "H", "E", "M", "BW Time (ms)"))
+        for N, L, H, E, M in [
+            [8, 4096, 8, 512, 512],
+            [1, 4096, 8, 512, 512],
+            [16, 512, 8, 512, 512],
+            [16, 128, 8, 512, 512],
+            [1, 128, 8, 512, 512],
+            [16, 4096, 1, 512, 512],
+            [16, 4096, 8, 64, 64],
+        ]:
+            Q = torch.rand(N, H, L, E).cuda()
+            K = torch.rand(N, H, L, E).cuda()
+            V = torch.rand(N, H, L, M).cuda()
+            go = torch.rand(N, H, L, M).cuda()
+            gq, gk, gv = [torch.zeros_like(x) for x in [Q, K, V]]
 
-        # warmup the cache
-        for i in range(10):
-            self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
+            # warmup the cache
+            for i in range(10):
+                self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
 
-        # measure
-        start = torch.cuda.Event(enable_timing=True)
-        end = torch.cuda.Event(enable_timing=True)
-        start.record()
-        for i in range(10):
-            self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
-        end.record()
-        torch.cuda.synchronize()
-        print("[{}] GPU time taken: {} (ms)".format(
-            CP,
-            start.elapsed_time(end)
-        ))
+            # measure
+            start = torch.cuda.Event(enable_timing=True)
+            end = torch.cuda.Event(enable_timing=True)
+            start.record()
+            for i in range(10):
+                self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
+            end.record()
+            torch.cuda.synchronize()
+            print("{:>5} {:>5} {:>5} {:>5} {:>5} {:>8.1f}".format(
+                N, L, H, E, M,
+                start.elapsed_time(end)
+            ))
 
     def test_result_forward(self):
         for k in self.kernels.keys():

--- a/tests/causal_product/test_causal_product_gpu.py
+++ b/tests/causal_product/test_causal_product_gpu.py
@@ -84,71 +84,61 @@ class TestCausalProductCUDA(unittest.TestCase):
             self.assertLess(max_relative_error(V.grad, gv), 1e-5)
 
     def _test_benchmark_forward(self, CP):
-        print("{:>4} {:>5} {:>5} {:>5} {:>5} {:>12}".format("N", "L", "H", "E", "M", "FW Time (ms)"))
-        for N, L, H, E, M in [
-            [8, 4096, 8, 512, 512],
-            [1, 4096, 8, 512, 512],
-            [16, 512, 8, 512, 512],
-            [16, 128, 8, 512, 512],
-            [1, 128, 8, 512, 512],
-            [16, 4096, 1, 512, 512],
-            [16, 4096, 8, 64, 64],
-        ]:
-            Q = torch.rand(N, H, L, E).cuda()
-            K = torch.rand(N, H, L, E).cuda()
-            V = torch.rand(N, H, L, M).cuda()
-            out = torch.rand(N, H, L, M).cuda()
+        N = 10
+        L = 1000
+        H = 10
+        E = 32
+        M = 64
+        Q = torch.rand(N, H, L, E).cuda()
+        K = torch.rand(N, H, L, E).cuda()
+        V = torch.rand(N, H, L, M).cuda()
+        out = torch.rand(N, H, L, M).cuda()
 
-            # warmup the cache
-            for i in range(10):
-                self.kernels[CP]["forward"](Q, K, V, out)
+        # warmup the cache
+        for i in range(10):
+            self.kernels[CP]["forward"](Q, K, V, out)
 
-            # measure
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
-            start.record()
-            for i in range(10):
-                self.kernels[CP]["forward"](Q, K, V, out)
-            end.record()
-            torch.cuda.synchronize()
-            print("{:>5} {:>5} {:>5} {:>5} {:>5} {:>8.1f}".format(
-                N, L, H, E, M,
-                start.elapsed_time(end)
-            ))
+        # measure
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for i in range(10):
+            self.kernels[CP]["forward"](Q, K, V, out)
+        end.record()
+        torch.cuda.synchronize()
+        print("[{}] GPU time taken: {} (ms)".format(
+            CP,
+            start.elapsed_time(end)
+        ))
 
     def _test_benchmark_backward(self, CP):
-        print("{:>4} {:>5} {:>5} {:>5} {:>5} {:>12}".format("N", "L", "H", "E", "M", "BW Time (ms)"))
-        for N, L, H, E, M in [
-            [8, 4096, 8, 512, 512],
-            [1, 4096, 8, 512, 512],
-            [16, 512, 8, 512, 512],
-            [16, 128, 8, 512, 512],
-            [1, 128, 8, 512, 512],
-            [16, 4096, 1, 512, 512],
-            [16, 4096, 8, 64, 64],
-        ]:
-            Q = torch.rand(N, H, L, E).cuda()
-            K = torch.rand(N, H, L, E).cuda()
-            V = torch.rand(N, H, L, M).cuda()
-            go = torch.rand(N, H, L, M).cuda()
-            gq, gk, gv = [torch.zeros_like(x) for x in [Q, K, V]]
+        N = 10
+        L = 1000
+        H = 10
+        E = 32
+        M = 64
+        Q = torch.rand(N, H, L, E).cuda()
+        K = torch.rand(N, H, L, E).cuda()
+        V = torch.rand(N, H, L, M).cuda()
+        go = torch.rand(N, H, L, M).cuda()
+        gq, gk, gv = [torch.zeros_like(x) for x in [Q, K, V]]
 
-            # warmup the cache
-            for i in range(10):
-                self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
+        # warmup the cache
+        for i in range(10):
+            self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
 
-            # measure
-            start = torch.cuda.Event(enable_timing=True)
-            end = torch.cuda.Event(enable_timing=True)
-            start.record()
-            for i in range(10):
-                self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
-            end.record()
-            torch.cuda.synchronize()
-            print("{:>5} {:>5} {:>5} {:>5} {:>5} {:>8.1f}".format(
-                N, L, H, E, M,
-                start.elapsed_time(end)
-            ))
+        # measure
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for i in range(10):
+            self.kernels[CP]["backward"](Q, K, V, go, gq, gk, gv)
+        end.record()
+        torch.cuda.synchronize()
+        print("[{}] GPU time taken: {} (ms)".format(
+            CP,
+            start.elapsed_time(end)
+        ))
 
     def test_result_forward(self):
         for k in self.kernels.keys():


### PR DESCRIPTION
### Summary

This branch optimizes the `causal_dot_product_` and `causal_dot_backward_` functions and related kernels for models with larger hidden sizes.

### Motivations

#77 made the CUDA kernels for causal product much faster, especially for the benchmarks where the head `H=8` and hidden sizes `E = M = 64` as in the paper. However, it **falls back** to the original implementation when the hidden size is larger, e.g., using one head (N=16, L=4096, H=1, E=M=512), and becomes significant slower and hard to scale up.

To tackle this issue, this commit optimizes the original (fallback) implementation. This new code uses much less `sync_threads`s and `atomicAdd`s and less shared memory.

### Benchmark Results

To profile its results in more extensive settings, use the following code:

```python
def _test_benchmark_forward(self, CP):
    print("{:>4} {:>5} {:>5} {:>5} {:>5} {:>12}".format("N", "L", "H", "E", "M", "FW Time (ms)"))
    for N, L, H, E, M in [
        [8, 4096, 8, 512, 512],
        [1, 4096, 8, 512, 512],
        [16, 4096, 1, 512, 512],
        [16, 4096, 8, 256, 256],
        [16, 4096, 8, 128, 128],
        [16, 4096, 8, 64, 64],
    ]:
        Q = torch.rand(N, H, L, E).cuda()
        K = torch.rand(N, H, L, E).cuda()
        V = torch.rand(N, H, L, M).cuda()
        out = torch.rand(N, H, L, M).cuda()

        # warmup the cache
        for i in range(10):
            self.kernels[CP]["forward"](Q, K, V, out)

        # measure
        start = torch.cuda.Event(enable_timing=True)
        end = torch.cuda.Event(enable_timing=True)
        start.record()
        for i in range(10):
            self.kernels[CP]["forward"](Q, K, V, out)
        end.record()
        torch.cuda.synchronize()
        print("{:>5} {:>5} {:>5} {:>5} {:>5} {:>8.1f}".format(
            N, L, H, E, M,
            start.elapsed_time(end)
        ))
```

#### Forward Pass

* New

```
    N     L     H     E     M Time (ms)
    8  4096     8   512   512   2541.4
    1  4096     8   512   512    311.2
   16  4096     1   512   512    630.6
   16  4096     8   256   256   1235.1
   16  4096     8   128   128     65.2
   16  4096     8    64    64     20.0
```

* Old

```
    N     L     H     E     M Time (ms)
    8  4096     8   512   512   7863.3
    1  4096     8   512   512   1008.9
   16  4096     1   512   512   1988.6
   16  4096     8   256   256   3666.2
   16  4096     8   128   128     63.1
   16  4096     8    64    64     20.9
```

#### Backward Pass

* New

```
   N     L     H     E     M Time (ms)
    8  4096     8   512   512   8765.8
    1  4096     8   512   512    978.9
   16  4096     1   512   512   1981.6
   16  4096     8   256   256   4507.5
   16  4096     8   128   128    180.9
   16  4096     8    64    64     52.3
```

* Old

```
   N     L     H     E     M Time (ms)
    8  4096     8   512   512  29759.8
    1  4096     8   512   512   3938.9
   16  4096     1   512   512   7775.5
   16  4096     8   256   256  11615.8
   16  4096     8   128   128    184.1
   16  4096     8    64    64     54.1
```