### PR TITLE
Fix #106 and #121

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 *.egg-info
 *.so
 *.swp
+*.pyd

--- a/fast_transformers/clustering/hamming/cluster_cpu.cpp
+++ b/fast_transformers/clustering/hamming/cluster_cpu.cpp
@@ -16,25 +16,9 @@
         return __builtin_popcountll(x);
     }
 #elif _MSC_VER
-    //Code Borrowed from llvm-libc++, MIT license
-    inline int popcnt(int64_t x)
-    {
-      // Binary: 0101...
-      static const unsigned long long m1 = 0x5555555555555555;
-      // Binary: 00110011..
-      static const unsigned long long m2 = 0x3333333333333333;
-      // Binary:  4 zeros,  4 ones ...
-      static const unsigned long long m4 = 0x0f0f0f0f0f0f0f0f;
-      // The sum of 256 to the power of 0,1,2,3...
-      static const unsigned long long h01 = 0x0101010101010101;
-      // Put count of each 2 bits into those 2 bits.
-      x -= (x >> 1) & m1;
-      // Put count of each 4 bits into those 4 bits.
-      x = (x & m2) + ((x >> 2) & m2);
-      // Put count of each 8 bits into those 8 bits.
-      x = (x + (x >> 4)) & m4;
-      // Returns left 8 bits of x + (x<<8) + (x<<16) + (x<<24) + ...
-      return static_cast<int>((x * h01) >> 56);
+    #include <intrin.h>
+    inline int popcnt(int64_t x) {
+        return static_cast<int>(__popcnt64(x));
     }
 #else
     #error "Popcnt not implemented"
@@ -131,7 +115,7 @@ void recompute_centroids(
     auto length_a = lengths.accessor<int32_t, 1>();
     auto centroid_a = centroids.accessor<int64_t, 3>();
 
-    ThreadSafePRNG prng(0, (1UL<<bits)-1UL);  // see the class comment on why
+    ThreadSafePRNG prng(0, (1ULL<<bits)-1ULL);  // see the class comment on why
 
     #pragma omp parallel for
     for (int n=0; n<N; n++) {
@@ -158,7 +142,7 @@ void recompute_centroids(
                     if (cluster_a[n][h][l] == k) {
                         int64_t hash = hash_a[n][h][l];
                         for (int b=0; b<bits; b++) {
-                            if (hash & 1L<<b) {
+                            if (hash & (1LL<<b)) {
                                 counts[b]++;
                             } else {
                                 counts[b]--;
@@ -179,7 +163,7 @@ void recompute_centroids(
                     centroid_a[n][h][k] = c;
                 } else {
                     int64_t c = prng.random();
-                    centroid_a[n][h][k] = c & ((1L<<bits)-1);
+                    centroid_a[n][h][k] = c & ((1LL<<bits)-1LL);
                 }
             }
         }

--- a/fast_transformers/clustering/hamming/cluster_cuda.cu
+++ b/fast_transformers/clustering/hamming/cluster_cuda.cu
@@ -162,7 +162,7 @@ void bit_count_kernel(
     }
 
     for (int i=0; i<B; i++) {
-        int64_t bit= 1L << i;
+        int64_t bit= 1LL << i;
         if((x & bit) > 0) {
             val_to_add = 1;
         }
@@ -210,7 +210,7 @@ void compute_means_kernel(
     const int k = full_idx % K;
 
     int64_t mean_k = 0;
-    const int64_t MAX = (1L << (B));
+    const int64_t MAX = (1LL << (B));
 
     // if the counts for the current cluster is 0 set mean to random
     if(counts[n][h][k] == 0) {
@@ -222,10 +222,10 @@ void compute_means_kernel(
     for( int i=0; i<B; i++) {
         if(cluster_bit_counts[n][h][k][i] == 0) {
             cluster_bit_counts[n][h][k][i] =
-                (curand(state + k) & 1L);
+                (curand(state + k) & 1LL);
         }
         if(cluster_bit_counts[n][h][k][i] > 0) {
-            mean_k = mean_k | (1L << i);
+            mean_k = mean_k | (1LL << i);
         }
     }
     centroids[n][h][k] = mean_k;

--- a/fast_transformers/feature_maps/fourier_features.py
+++ b/fast_transformers/feature_maps/fourier_features.py
@@ -34,7 +34,7 @@ def orthogonal_random_matrix_(w):
         end = min(start+rows, columns)
         block = torch.randn(rows, rows, device=w.device)
         norms = torch.sqrt(torch.einsum("ab,ab->a", block, block))
-        Q, _ = torch.qr(block)
+        Q, _ = torch.linalg.qr(block)
         w[:, start:end] = (
             Q[:, :end-start] * norms[None, :end-start]
         )

--- a/fast_transformers/local_product/local_product_cuda.cu
+++ b/fast_transformers/local_product/local_product_cuda.cu
@@ -12,7 +12,7 @@
 typedef torch::PackedTensorAccessor32<float, 4, torch::RestrictPtrTraits> float4_accessor;
 typedef torch::PackedTensorAccessor32<float, 3, torch::RestrictPtrTraits> float3_accessor;
 typedef torch::PackedTensorAccessor32<float, 2, torch::RestrictPtrTraits> float2_accessor;
-typedef torch::PackedTensorAccessor32<long, 1, torch::RestrictPtrTraits> long_accessor;
+typedef torch::PackedTensorAccessor32<int64_t, 1, torch::RestrictPtrTraits> long_accessor;
 
 
 inline int ceildiv(int a, int b) {
@@ -77,7 +77,7 @@ struct masked_lp_copy
     ) {
         return masked_lp_copy(
             attn_mask.packed_accessor32<float, 2, torch::RestrictPtrTraits>(),
-            key_lengths.packed_accessor32<long, 1, torch::RestrictPtrTraits>(),
+            key_lengths.packed_accessor32<int64_t, 1, torch::RestrictPtrTraits>(),
             n_heads
         );
     }


### PR DESCRIPTION
Fix #106 
Fix #121

- replace non-crossplatform `long` with `int64_t`
- fix failing unit-tests
- replace `popcnt` with intrinsic
